### PR TITLE
Skill section sticky not working in deployed environment

### DIFF
--- a/src/components/PageLayout.tsx
+++ b/src/components/PageLayout.tsx
@@ -19,7 +19,7 @@ const MainContainer = styled.main<{
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
   position: relative;
-  overflow: visible;
+  /* overflow 속성 제거 - sticky 요소가 제대로 작동하도록 */
 
   /* 페이지별 배경 그라데이션 */
   ${(props) => {

--- a/src/styles/GlobalStyle.ts
+++ b/src/styles/GlobalStyle.ts
@@ -49,7 +49,7 @@ const GlobalStyle = createGlobalStyle`
   html,
   body {
     max-width: 100vw;
-    overflow-x: hidden;
+    overflow-x: clip; /* overflow-x: hidden은 sticky를 방해할 수 있어 clip으로 변경 */
   }
 
   /* 반응형 미디어 쿼리 */

--- a/src/styles/SkillsSection.ts
+++ b/src/styles/SkillsSection.ts
@@ -6,7 +6,7 @@ export const SkillsSection = styled.section`
   min-height: 100vh;
   padding: 2rem 0;
   position: relative;
-  overflow: visible;
+  /* overflow 제거 - sticky 작동을 위해 */
   isolation: isolate;
   scroll-margin-top: 100px;
 
@@ -20,7 +20,8 @@ export const SkillsContainer = styled.div`
   width: 100%;
   margin: 0 auto;
   position: relative;
-
+  /* overflow 제거 - sticky가 작동하도록 */
+  
   @media (max-width: 768px) {
     padding: 0 1rem;
   }
@@ -28,13 +29,18 @@ export const SkillsContainer = styled.div`
 
 export const StickyTitleContainer = styled.div`
   position: sticky;
+  position: -webkit-sticky; /* Safari 지원 */
   top: 120px;
   text-align: center;
   height: fit-content;
   width: 300px;
-  z-index: 100;
+  z-index: 10; /* Navbar(100)보다 낮게 설정 */
   float: left;
   margin-right: 4rem;
+  will-change: transform; /* 성능 개선 */
+  
+  /* sticky가 작동하기 위한 추가 설정 */
+  align-self: flex-start;
 
   @media (max-width: 768px) {
     position: static;


### PR DESCRIPTION
Fix sticky positioning of the skill section by adjusting overflow properties and sticky element styles for better browser compatibility and z-index management.

The sticky feature was not working in the deployed environment due to conflicting `overflow` properties on parent elements (especially `overflow-x: hidden` on `html`/`body`), lack of Safari compatibility, and z-index conflicts with the Navbar. These changes address those issues.

---
<a href="https://cursor.com/background-agent?bcId=bc-335ec346-d257-46c3-ab52-914160e5abcf">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-335ec346-d257-46c3-ab52-914160e5abcf">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

